### PR TITLE
Include license in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENCE


### PR DESCRIPTION
Include license in sdist by adding a MANIFEST.in file.